### PR TITLE
Migrate to kotest 6.0.0.M4. Fix report rewriting

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 dokka = "1.9.10"
-kotest = "5.9.1"
+kotest = "6.0.0.M4"
 kotlin = "2.1.20"
 kotlin-html = "0.12.0"
 ktlint = "0.48.2"

--- a/src/main/kotlin/mjs/kotest/BuildReportWriter.kt
+++ b/src/main/kotlin/mjs/kotest/BuildReportWriter.kt
@@ -28,9 +28,8 @@ internal object BuildReportWriter {
 
     internal fun writeReportFile(outputDir: String, fileName: String, fileContents: String) {
         val path = outputDir(outputDir).resolve(fileName)
-        if (path.parent.toFile().mkdirs()) {
-            path.toFile().writeText(fileContents)
-        }
+        path.parent.toFile().mkdirs()
+        path.toFile().writeText(fileContents)
     }
 
     private fun outputDir(outputDir: String): Path {

--- a/src/main/kotlin/mjs/kotest/DefaultResources.kt
+++ b/src/main/kotlin/mjs/kotest/DefaultResources.kt
@@ -15,10 +15,13 @@
 */
 package mjs.kotest
 
+import org.intellij.lang.annotations.Language
+
 /**
  * Default CSS to load if `html-reporter.css` is not available on the classpath.
  * It should contain an exact copy of that file.
  */
+@Language("CSS")
 internal const val DefaultCss = """
 * {
     font-family: sans-serif;
@@ -32,6 +35,11 @@ h2 {
 .code {
     font-family: monospace;
     background-color: #EEEEEE;
+}
+
+.name {
+    padding-left: 2px;
+    padding-right: 2px;
 }
 
 .timestamp {

--- a/src/main/kotlin/mjs/kotest/SpecReportBuilder.kt
+++ b/src/main/kotlin/mjs/kotest/SpecReportBuilder.kt
@@ -72,8 +72,8 @@ internal object SpecReportBuilder {
 
     private val TestCase.reportingName: String
         get() = when (spec) {
-            is BehaviorSpec -> with(name) { (prefix ?: "") + testName + (suffix ?: "") }
-            else -> name.testName
+            is BehaviorSpec -> with(name) { (prefix ?: "") + name + (suffix ?: "") }
+            else -> name.name
         }
 
     /** Format a positive [Duration] to string in milliseconds, else null.  */

--- a/src/main/resources/mjs/kotest/html-reporter.css
+++ b/src/main/resources/mjs/kotest/html-reporter.css
@@ -17,6 +17,11 @@ h2 {
     background-color: #EEEEEE;
 }
 
+.name {
+    padding-left: 2px;
+    padding-right: 2px;
+}
+
 .timestamp {
     line-height: 1.4;
     font-size: 1em;

--- a/src/test/kotlin/mjs/kotest/KotestConfig.kt
+++ b/src/test/kotlin/mjs/kotest/KotestConfig.kt
@@ -20,7 +20,7 @@ import io.kotest.core.extensions.Extension
 
 /** Create an HTML report for every test run. */
 object KotestConfig : AbstractProjectConfig() {
-    override fun extensions(): List<Extension> = listOf(
+    override val extensions: List<Extension> = listOf(
         HtmlReporter(reportFilename = "index.html"),
     )
 }

--- a/src/test/kotlin/mjs/kotest/SpecReportBuilderTest.kt
+++ b/src/test/kotlin/mjs/kotest/SpecReportBuilderTest.kt
@@ -31,10 +31,10 @@ class SpecReportBuilderTest : DescribeSpec({
     val thisSpec = this
     describe("`reportFromResults()` function") {
         it("converts `Error` result to `Failure`") {
-            val specDescriptor = Descriptor.SpecDescriptor(DescriptorId("SpecReportBuilderTest.kt"), thisSpec::class)
+            val specDescriptor = Descriptor.SpecDescriptor(DescriptorId("SpecReportBuilderTest.kt"))
             val name = "error result"
             val descriptor = Descriptor.TestDescriptor(specDescriptor, DescriptorId(name))
-            val case = TestCase(descriptor, TestName(name), thisSpec, {}, type = TestType.Test)
+            val case = TestCase(descriptor, TestName(name, false, false, null, null, false), thisSpec, {}, type = TestType.Test)
             val errorResult = TestResult.Error(Duration.parse("16.342524ms"), NullPointerException("Oh noes!"))
 
             val report = reportFromResults(randomWord(), mapOf(case to errorResult))

--- a/src/test/kotlin/mjs/kotest/fixtures/ThingTestCases.kt
+++ b/src/test/kotlin/mjs/kotest/fixtures/ThingTestCases.kt
@@ -25,17 +25,17 @@ import io.kotest.core.test.TestResult
 import io.kotest.core.test.TestType
 import kotlin.time.Duration
 
-val specDescriptor = Descriptor.SpecDescriptor(DescriptorId(ThingTest::class.qualifiedName!!), ThingTest::class)
+val specDescriptor = Descriptor.SpecDescriptor(DescriptorId(ThingTest::class.qualifiedName!!))
 val thingTest = ThingTest()
 
 const val name0 = "0. Describe the thing"
 val descriptor0 = Descriptor.TestDescriptor(specDescriptor, DescriptorId(name0))
 val case0 = TestCase(
     descriptor0,
-    TestName(name0),
+    TestName(name0, false, false, null, null, false),
     thingTest,
     {},
-    SourceRef.FileSource("ThingTest.kt", 8),
+    SourceRef.ClassSource(ThingTest::class.java.name, 8),
     TestType.Container,
     parent = null,
 )
@@ -45,10 +45,10 @@ const val name1 = "1. I don’t care"
 val descriptor1 = Descriptor.TestDescriptor(descriptor0, DescriptorId(name1))
 val case1 = TestCase(
     descriptor1,
-    TestName(name1),
+    TestName(name1, false, false, null, null, false),
     thingTest,
     {},
-    SourceRef.FileSource("ThingTest.kt", 9),
+    SourceRef.ClassSource(ThingTest::class.java.name, 9),
     TestType.Test,
     parent = case0,
 )
@@ -58,10 +58,10 @@ const val name2 = "2. the inner thing"
 val descriptor2 = Descriptor.TestDescriptor(descriptor0, DescriptorId(name2))
 val case2 = TestCase(
     descriptor2,
-    TestName(name2),
+    TestName(name2, false, false, null, null, false),
     thingTest,
     {},
-    SourceRef.FileSource("ThingTest.kt", 12),
+    SourceRef.ClassSource(ThingTest::class.java.name, 12),
     TestType.Container,
     parent = case0,
 )
@@ -71,10 +71,10 @@ const val name2a = "2a. is thing"
 val descriptor2a = Descriptor.TestDescriptor(descriptor2, DescriptorId(name2a))
 val case2a = TestCase(
     descriptor2a,
-    TestName(name2a),
+    TestName(name2a, false, false, null, null, false),
     thingTest,
     {},
-    SourceRef.FileSource("ThingTest.kt", 13),
+    SourceRef.ClassSource(ThingTest::class.java.name, 13),
     TestType.Test,
     parent = case2,
 )
@@ -84,10 +84,10 @@ const val name2b = "2b. is not thang"
 val descriptor2b = Descriptor.TestDescriptor(descriptor2, DescriptorId(name2b))
 val case2b = TestCase(
     descriptor2b,
-    TestName(name2b),
+    TestName(name2b, false, false, null, null, false),
     thingTest,
     {},
-    SourceRef.FileSource("ThingTest.kt", 16),
+    SourceRef.ClassSource(ThingTest::class.java.name, 16),
     TestType.Test,
     parent = case2,
 )
@@ -100,10 +100,10 @@ const val name3 = "3. also ignored"
 val descriptor3 = Descriptor.TestDescriptor(descriptor0, DescriptorId(name3))
 val case3 = TestCase(
     descriptor3,
-    TestName(name3),
+    TestName(name3, false, false, null, null, false),
     thingTest,
     {},
-    SourceRef.FileSource("ThingTest.kt", 20),
+    SourceRef.ClassSource(ThingTest::class.java.name, 20),
     TestType.Container,
     parent = case0,
 )


### PR DESCRIPTION
1. Migrate code to Kotest 6.0.0.M4
2. Fix bug: The report did not overwrite the already created file. mkdirs() returns true only the first time it creates a report file.
3. Add paddings for name CSS class
![image](https://github.com/user-attachments/assets/3aa5cd80-fa04-4314-b75e-3c796e5a8783)
